### PR TITLE
added -n flag to read utility and small tweaks

### DIFF
--- a/user/coreutils/read.c
+++ b/user/coreutils/read.c
@@ -20,7 +20,7 @@ int main(int argc, char *argv[]) {
             putc(buf[i]);
         }
     }
-    
+    printf("\n");
     handle_close(file);
     return 0;
 }

--- a/user/coreutils/read.c
+++ b/user/coreutils/read.c
@@ -1,9 +1,10 @@
+#include <string.h>
 #include <system.h>
 #include <io.h>
 
 int main(int argc, char *argv[]) {
     if (argc < 2) {
-        puts("Usage: read <file>\n");
+        puts("Usage: read <file> [-n | --new-line]\n");
         return 1;
     }
     
@@ -11,6 +12,11 @@ int main(int argc, char *argv[]) {
     if (file == INVALID_HANDLE) {
         printf("read: cannot open '%s'\n", argv[1]);
         return 1;
+    }
+    bool add_new_line = false;
+
+    if (argc >= 3 && (streq(argv[2], "-n") || streq(argv[2], "--new-line"))) {
+	add_new_line = true;
     }
     
     char buf[512];
@@ -20,7 +26,8 @@ int main(int argc, char *argv[]) {
             putc(buf[i]);
         }
     }
-    printf("\n");
+
+    if (add_new_line) printf("\n");
     handle_close(file);
     return 0;
 }

--- a/user/src/shell/shell.c
+++ b/user/src/shell/shell.c
@@ -30,10 +30,6 @@ static void cmd_help(void) {
     puts("Commands: help, echo, cd, pwd, spawn, wm, dir, exit\n");
 }
 
-static void cmd_echo(char *args) {
-    if (args) puts(args);
-    puts("\n");
-}
 
 static void cmd_spawn(char *path) {
     if (!path) {
@@ -79,8 +75,6 @@ static void process_command(char *line) {
     
     if (streq(cmd, "help")) {
         cmd_help();
-    } else if (streq(cmd, "echo")) {
-        cmd_echo(strtok(NULL, "\n"));
     } else if (streq(cmd, "cd")) {
         cmd_cd(strtok(NULL, " \t\n"));
     } else if (streq(cmd, "pwd")) {

--- a/web/index.html
+++ b/web/index.html
@@ -170,7 +170,7 @@
             <div class="box titlebar" role="navigation" aria-label="Application title bar">
                 <nav class="actions" aria-label="Primary actions">
                     <a class="btn" href="#forum" role="button">Forum</a>
-                    <a class="btn" href="#github" role="button">GitHub</a>
+                    <a class="btn" target="_blank" href="https://www.github.com/deltaoperatingsystem/deltaos" role="button">GitHub</a>
                     <a class="btn" href="#about" role="button">About</a>
                 </nav>
 


### PR DESCRIPTION
I added `-n` and `--new-line` to read utility to print a trailing new line after the file and fixed the shell to use `system/binaries/echo` executable instead of `cmd_echo` function and added the actual link of the repo in `index.html`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added optional `-n`/`--new-line` flag to the `read` command to append a newline after reading input.

* **Changes**
  * Removed `echo` command from shell.

* **Updates**
  * Updated GitHub navigation link to open externally in a new window.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->