### PR TITLE
Fancy env vars/process context

### DIFF
--- a/kernel/proc/context.c
+++ b/kernel/proc/context.c
@@ -1,0 +1,411 @@
+#include <proc/context.h>
+#include <mm/kheap.h>
+#include <lib/string.h>
+
+#define PROC_CONTEXT_INITIAL_CAPACITY 8
+
+/*
+ *process context is a kernel-owned key/value table that travels with a
+ *process
+  scalars are copied into the table directly, while object entries
+ * retain an object reference plus the rights snapshot that should be used when
+ * the entry is later materialized as a handle again
+ */
+
+//reject empty keys and unbounded names up front so every stored entry can be
+//handled with fixed-size scratch buffers in the syscall layer
+static int proc_context_validate_key(const char *key) {
+    if (!key || !key[0]) return -1;
+    if (strlen(key) >= PROC_CONTEXT_KEY_MAX) return -1;
+    return 0;
+}
+
+//Free whatever payload the entry currently owns, then clear it back to zero
+static void proc_context_release_entry(proc_context_entry_t *entry) {
+    if (!entry) return;
+
+    if (entry->type == PROC_CONTEXT_VALUE_STRING && entry->value.str) {
+        kfree(entry->value.str);
+    } else if (entry->type == PROC_CONTEXT_VALUE_OBJECT && entry->value.object.obj) {
+        object_deref(entry->value.object.obj);
+    }
+
+    if (entry->key) {
+        kfree(entry->key);
+    }
+
+    memset(entry, 0, sizeof(*entry));
+}
+
+static proc_context_entry_t *proc_context_find_locked(const proc_context_t *ctx, const char *key) {
+    if (!ctx || !key) return NULL;
+
+    for (size i = 0; i < ctx->count; i++) {
+        if (ctx->entries[i].key && strcmp(ctx->entries[i].key, key) == 0) {
+            return &ctx->entries[i];
+        }
+    }
+
+    return NULL;
+}
+
+// Grow the backing array lazily so an empty context stays allocation-free.
+static int proc_context_ensure_capacity_locked(proc_context_t *ctx) {
+    if (ctx->count < ctx->capacity) return 0;
+
+    size new_capacity = ctx->capacity ? (ctx->capacity * 2) : PROC_CONTEXT_INITIAL_CAPACITY;
+    proc_context_entry_t *new_entries = krealloc(ctx->entries, new_capacity * sizeof(proc_context_entry_t));
+    if (!new_entries) return -1;
+
+    for (size i = ctx->capacity; i < new_capacity; i++) {
+        memset(&new_entries[i], 0, sizeof(new_entries[i]));
+    }
+
+    ctx->entries = new_entries;
+    ctx->capacity = new_capacity;
+    return 0;
+}
+
+//reserve a slot for a key update while the context lock is held
+//the table stays densely packed, so this helper either reuses the existing
+//slot for the key or appends one fresh entry at the end of the array
+static proc_context_entry_t *proc_context_reserve_entry_locked(proc_context_t *ctx, const char *key, uint32 flags) {
+    proc_context_entry_t *entry = proc_context_find_locked(ctx, key);
+    if (entry) {
+        if (entry->flags & PROC_CONTEXT_FLAG_READONLY) {
+            return NULL;
+        }
+
+        //replacing an entry always tears down the previous payload first so we
+        //cannot accidentally leak a stale object ref or heap string
+        proc_context_release_entry(entry);
+    } else {
+        if (proc_context_ensure_capacity_locked(ctx) != 0) return NULL;
+        entry = &ctx->entries[ctx->count++];
+        memset(entry, 0, sizeof(*entry));
+    }
+
+    size key_len = strlen(key) + 1;
+    entry->key = kmalloc(key_len);
+    if (!entry->key) {
+        memset(entry, 0, sizeof(*entry));
+        return NULL;
+    }
+
+    memcpy(entry->key, key, key_len);
+    entry->flags = flags & PROC_CONTEXT_FLAG_VALID_MASK;
+    return entry;
+}
+
+//shared scalar setter used by the i64/u64/bool entry helpers
+//scalars are stored inline in the entry payload, so the only heap ownership
+//involved here is the entry key itself
+static int proc_context_set_scalar(proc_context_t *ctx, const char *key, uint32 type,
+                                   const void *value, uint32 flags) {
+    if (!ctx || proc_context_validate_key(key) != 0 || !value) return -1;
+    if ((flags & ~PROC_CONTEXT_FLAG_VALID_MASK) != 0) return -1;
+
+    spinlock_acquire(&ctx->lock);
+    proc_context_entry_t *entry = proc_context_reserve_entry_locked(ctx, key, flags);
+    if (!entry) {
+        spinlock_release(&ctx->lock);
+        return -1;
+    }
+
+    entry->type = type;
+    if (type == PROC_CONTEXT_VALUE_I64) {
+        entry->value.i64 = *(const int64 *)value;
+    } else if (type == PROC_CONTEXT_VALUE_U64) {
+        entry->value.u64 = *(const uint64 *)value;
+    } else if (type == PROC_CONTEXT_VALUE_BOOL) {
+        entry->value.boolean = *(const uint8 *)value ? 1 : 0;
+    } else {
+        proc_context_release_entry(entry);
+        spinlock_release(&ctx->lock);
+        return -1;
+    }
+
+    spinlock_release(&ctx->lock);
+    return 0;
+}
+
+void proc_context_init(proc_context_t *ctx) {
+    if (!ctx) return;
+
+    ctx->entries = NULL;
+    ctx->count = 0;
+    ctx->capacity = 0;
+    spinlock_init(&ctx->lock);
+}
+
+//destroy the entire table and release every heap/object payload it owns
+void proc_context_destroy(proc_context_t *ctx) {
+    if (!ctx) return;
+
+    spinlock_acquire(&ctx->lock);
+    for (size i = 0; i < ctx->count; i++) {
+        proc_context_release_entry(&ctx->entries[i]);
+    }
+
+    if (ctx->entries) {
+        kfree(ctx->entries);
+    }
+
+    ctx->entries = NULL;
+    ctx->count = 0;
+    ctx->capacity = 0;
+    spinlock_release(&ctx->lock);
+}
+
+int proc_context_clone_for_child(proc_context_t *dst, const proc_context_t *src) {
+    if (!dst || !src) return -1;
+
+    //child creation only needs inherited entries non-inheritable entries stay
+    //private to the current process and never appear in descendants
+    spinlock_acquire((spinlock_t *)&src->lock);
+    for (size i = 0; i < src->count; i++) {
+        proc_context_entry_t *entry = &src->entries[i];
+        int rc = 0;
+
+        if (!entry->key || !(entry->flags & PROC_CONTEXT_FLAG_INHERIT)) {
+            continue;
+        }
+
+        //clone through the public setters so copied entries keep exactly the
+        //same ownership rules as if userspace had created them directly
+        if (entry->type == PROC_CONTEXT_VALUE_STRING) {
+            rc = proc_context_set_string(dst, entry->key, entry->value.str, entry->flags);
+        } else if (entry->type == PROC_CONTEXT_VALUE_I64) {
+            rc = proc_context_set_i64(dst, entry->key, entry->value.i64, entry->flags);
+        } else if (entry->type == PROC_CONTEXT_VALUE_U64) {
+            rc = proc_context_set_u64(dst, entry->key, entry->value.u64, entry->flags);
+        } else if (entry->type == PROC_CONTEXT_VALUE_BOOL) {
+            rc = proc_context_set_bool(dst, entry->key, entry->value.boolean != 0, entry->flags);
+        } else if (entry->type == PROC_CONTEXT_VALUE_OBJECT) {
+            rc = proc_context_set_object(dst, entry->key, entry->value.object.obj,
+                                         entry->value.object.rights, entry->flags);
+        } else {
+            rc = -1;
+        }
+
+        if (rc != 0) {
+            //a partial child context is not useful, roll it back completely so
+            //callers either get a full inherited view or a hard failure
+            spinlock_release((spinlock_t *)&src->lock);
+            proc_context_destroy(dst);
+            proc_context_init(dst);
+            return -1;
+        }
+    }
+
+    spinlock_release((spinlock_t *)&src->lock);
+    return 0;
+}
+
+int proc_context_set_string(proc_context_t *ctx, const char *key, const char *value, uint32 flags) {
+    if (!ctx || proc_context_validate_key(key) != 0 || !value) return -1;
+    if ((flags & ~PROC_CONTEXT_FLAG_VALID_MASK) != 0) return -1;
+
+    //strings are copied into kernel-owned memory so userspace can free or
+    //mutate its source buffer immediately after the syscall returns
+    size value_len = strlen(value) + 1;
+    char *value_copy = kmalloc(value_len);
+    if (!value_copy) return -1;
+    memcpy(value_copy, value, value_len);
+
+    spinlock_acquire(&ctx->lock);
+    proc_context_entry_t *entry = proc_context_reserve_entry_locked(ctx, key, flags);
+    if (!entry) {
+        spinlock_release(&ctx->lock);
+        kfree(value_copy);
+        return -1;
+    }
+
+    entry->type = PROC_CONTEXT_VALUE_STRING;
+    entry->value.str = value_copy;
+    spinlock_release(&ctx->lock);
+    return 0;
+}
+
+int proc_context_set_i64(proc_context_t *ctx, const char *key, int64 value, uint32 flags) {
+    return proc_context_set_scalar(ctx, key, PROC_CONTEXT_VALUE_I64, &value, flags);
+}
+
+int proc_context_set_u64(proc_context_t *ctx, const char *key, uint64 value, uint32 flags) {
+    return proc_context_set_scalar(ctx, key, PROC_CONTEXT_VALUE_U64, &value, flags);
+}
+
+int proc_context_set_bool(proc_context_t *ctx, const char *key, int value, uint32 flags) {
+    uint8 boolean = value ? 1 : 0;
+    return proc_context_set_scalar(ctx, key, PROC_CONTEXT_VALUE_BOOL, &boolean, flags);
+}
+
+int proc_context_set_object(proc_context_t *ctx, const char *key, object_t *obj,
+                            handle_rights_t rights, uint32 flags) {
+    if (!ctx || proc_context_validate_key(key) != 0 || !obj) return -1;
+    if ((flags & ~PROC_CONTEXT_FLAG_VALID_MASK) != 0) return -1;
+
+    spinlock_acquire(&ctx->lock);
+    proc_context_entry_t *entry = proc_context_reserve_entry_locked(ctx, key, flags);
+    if (!entry) {
+        spinlock_release(&ctx->lock);
+        return -1;
+    }
+
+    //object entries pin the underlying object and remember the exact rights
+    //envelope that should be restored when turned back into a handle later
+    object_ref(obj);
+    entry->type = PROC_CONTEXT_VALUE_OBJECT;
+    entry->value.object.obj = obj;
+    entry->value.object.rights = rights;
+    spinlock_release(&ctx->lock);
+    return 0;
+}
+
+//remove one entry and compact the array so iteration order stays contiguous
+static int proc_context_remove_impl(proc_context_t *ctx, const char *key, int ignore_readonly) {
+    if (!ctx || proc_context_validate_key(key) != 0) return -1;
+
+    spinlock_acquire(&ctx->lock);
+    for (size i = 0; i < ctx->count; i++) {
+        proc_context_entry_t *entry = &ctx->entries[i];
+        if (!entry->key || strcmp(entry->key, key) != 0) {
+            continue;
+        }
+
+        if (!ignore_readonly && (entry->flags & PROC_CONTEXT_FLAG_READONLY)) {
+            spinlock_release(&ctx->lock);
+            return -1;
+        }
+
+        proc_context_release_entry(entry);
+
+        //keep the table densely packed so iteration and cloning stay simple
+        for (size j = i + 1; j < ctx->count; j++) {
+            ctx->entries[j - 1] = ctx->entries[j];
+        }
+        ctx->count--;
+        if (ctx->count < ctx->capacity) {
+            memset(&ctx->entries[ctx->count], 0, sizeof(ctx->entries[ctx->count]));
+        }
+
+        spinlock_release(&ctx->lock);
+        return 0;
+    }
+
+    spinlock_release(&ctx->lock);
+    return -1;
+}
+
+//remove one entry and respect the entry's read-only bit
+int proc_context_remove(proc_context_t *ctx, const char *key) {
+    return proc_context_remove_impl(ctx, key, 0);
+}
+
+//spawn-time overrides need a privileged path that can replace inherited
+//read-only entries before the child starts executing in userspace
+int proc_context_remove_force(proc_context_t *ctx, const char *key) {
+    return proc_context_remove_impl(ctx, key, 1);
+}
+
+//string getters duplicate the payload because syscall code needs to drop the
+//context lock before copying bytes back into userspace
+int proc_context_get_string_dup(const proc_context_t *ctx, const char *key, char **out_value,
+                                size *out_len, uint32 *out_flags) {
+    if (!ctx || proc_context_validate_key(key) != 0 || !out_value) return -1;
+
+    spinlock_acquire((spinlock_t *)&ctx->lock);
+    proc_context_entry_t *entry = proc_context_find_locked(ctx, key);
+    if (!entry || entry->type != PROC_CONTEXT_VALUE_STRING) {
+        spinlock_release((spinlock_t *)&ctx->lock);
+        return -1;
+    }
+
+    //getters hand back a detached copy so callers can drop the lock before
+    //exposing the data to other kernel subsystems or to userspace
+    size len = strlen(entry->value.str) + 1;
+    char *copy = kmalloc(len);
+    if (!copy) {
+        spinlock_release((spinlock_t *)&ctx->lock);
+        return -1;
+    }
+
+    memcpy(copy, entry->value.str, len);
+    if (out_len) *out_len = len;
+    if (out_flags) *out_flags = entry->flags;
+    *out_value = copy;
+    spinlock_release((spinlock_t *)&ctx->lock);
+    return 0;
+}
+
+//scalar getters just copy the inline value out while the context is locked
+int proc_context_get_i64(const proc_context_t *ctx, const char *key, int64 *out_value, uint32 *out_flags) {
+    if (!ctx || proc_context_validate_key(key) != 0 || !out_value) return -1;
+
+    spinlock_acquire((spinlock_t *)&ctx->lock);
+    proc_context_entry_t *entry = proc_context_find_locked(ctx, key);
+    if (!entry || entry->type != PROC_CONTEXT_VALUE_I64) {
+        spinlock_release((spinlock_t *)&ctx->lock);
+        return -1;
+    }
+
+    *out_value = entry->value.i64;
+    if (out_flags) *out_flags = entry->flags;
+    spinlock_release((spinlock_t *)&ctx->lock);
+    return 0;
+}
+
+int proc_context_get_u64(const proc_context_t *ctx, const char *key, uint64 *out_value, uint32 *out_flags) {
+    if (!ctx || proc_context_validate_key(key) != 0 || !out_value) return -1;
+
+    spinlock_acquire((spinlock_t *)&ctx->lock);
+    proc_context_entry_t *entry = proc_context_find_locked(ctx, key);
+    if (!entry || entry->type != PROC_CONTEXT_VALUE_U64) {
+        spinlock_release((spinlock_t *)&ctx->lock);
+        return -1;
+    }
+
+    *out_value = entry->value.u64;
+    if (out_flags) *out_flags = entry->flags;
+    spinlock_release((spinlock_t *)&ctx->lock);
+    return 0;
+}
+
+int proc_context_get_bool(const proc_context_t *ctx, const char *key, int *out_value, uint32 *out_flags) {
+    if (!ctx || proc_context_validate_key(key) != 0 || !out_value) return -1;
+
+    spinlock_acquire((spinlock_t *)&ctx->lock);
+    proc_context_entry_t *entry = proc_context_find_locked(ctx, key);
+    if (!entry || entry->type != PROC_CONTEXT_VALUE_BOOL) {
+        spinlock_release((spinlock_t *)&ctx->lock);
+        return -1;
+    }
+
+    *out_value = entry->value.boolean ? 1 : 0;
+    if (out_flags) *out_flags = entry->flags;
+    spinlock_release((spinlock_t *)&ctx->lock);
+    return 0;
+}
+
+//object getters hand back a fresh object reference so callers can materialize
+//a handle or inspect the object after the context lock has been released
+int proc_context_get_object_ref(const proc_context_t *ctx, const char *key, object_t **out_obj,
+                                handle_rights_t *out_rights, uint32 *out_flags) {
+    if (!ctx || proc_context_validate_key(key) != 0 || !out_obj || !out_rights) return -1;
+
+    spinlock_acquire((spinlock_t *)&ctx->lock);
+    proc_context_entry_t *entry = proc_context_find_locked(ctx, key);
+    if (!entry || entry->type != PROC_CONTEXT_VALUE_OBJECT || !entry->value.object.obj) {
+        spinlock_release((spinlock_t *)&ctx->lock);
+        return -1;
+    }
+
+    //callers receive a new ref so they can safely mint handles or inspect the
+    //object after dropping the context lock
+    object_ref(entry->value.object.obj);
+    *out_obj = entry->value.object.obj;
+    *out_rights = entry->value.object.rights;
+    if (out_flags) *out_flags = entry->flags;
+    spinlock_release((spinlock_t *)&ctx->lock);
+    return 0;
+}

--- a/kernel/proc/context.h
+++ b/kernel/proc/context.h
@@ -1,0 +1,71 @@
+#ifndef PROC_CONTEXT_H
+#define PROC_CONTEXT_H
+
+#include <arch/types.h>
+#include <obj/object.h>
+#include <obj/rights.h>
+#include <lib/spinlock.h>
+
+#define PROC_CONTEXT_KEY_MAX 96
+
+//entry payload kinds for the per-process runtime context
+typedef enum {
+    PROC_CONTEXT_VALUE_STRING = 1,
+    PROC_CONTEXT_VALUE_I64 = 2,
+    PROC_CONTEXT_VALUE_U64 = 3,
+    PROC_CONTEXT_VALUE_BOOL = 4,
+    PROC_CONTEXT_VALUE_OBJECT = 5
+} proc_context_value_type_t;
+
+//flag set for the version of the context ABI
+#define PROC_CONTEXT_FLAG_INHERIT   (1u << 0)
+#define PROC_CONTEXT_FLAG_READONLY  (1u << 1)
+#define PROC_CONTEXT_FLAG_VALID_MASK (PROC_CONTEXT_FLAG_INHERIT | PROC_CONTEXT_FLAG_READONLY)
+
+typedef struct {
+    object_t *obj;
+    handle_rights_t rights;
+} proc_context_object_t;
+
+typedef struct {
+    char *key;
+    uint32 type;
+    uint32 flags;
+    union {
+        char *str;
+        int64 i64;
+        uint64 u64;
+        uint8 boolean;
+        proc_context_object_t object;
+    } value;
+} proc_context_entry_t;
+
+typedef struct {
+    proc_context_entry_t *entries;
+    size count;
+    size capacity;
+    spinlock_t lock;
+} proc_context_t;
+
+void proc_context_init(proc_context_t *ctx);
+void proc_context_destroy(proc_context_t *ctx);
+int proc_context_clone_for_child(proc_context_t *dst, const proc_context_t *src);
+
+int proc_context_set_string(proc_context_t *ctx, const char *key, const char *value, uint32 flags);
+int proc_context_set_i64(proc_context_t *ctx, const char *key, int64 value, uint32 flags);
+int proc_context_set_u64(proc_context_t *ctx, const char *key, uint64 value, uint32 flags);
+int proc_context_set_bool(proc_context_t *ctx, const char *key, int value, uint32 flags);
+int proc_context_set_object(proc_context_t *ctx, const char *key, object_t *obj,
+                            handle_rights_t rights, uint32 flags);
+int proc_context_remove(proc_context_t *ctx, const char *key);
+int proc_context_remove_force(proc_context_t *ctx, const char *key);
+
+int proc_context_get_string_dup(const proc_context_t *ctx, const char *key, char **out_value,
+                                size *out_len, uint32 *out_flags);
+int proc_context_get_i64(const proc_context_t *ctx, const char *key, int64 *out_value, uint32 *out_flags);
+int proc_context_get_u64(const proc_context_t *ctx, const char *key, uint64 *out_value, uint32 *out_flags);
+int proc_context_get_bool(const proc_context_t *ctx, const char *key, int *out_value, uint32 *out_flags);
+int proc_context_get_object_ref(const proc_context_t *ctx, const char *key, object_t **out_obj,
+                                handle_rights_t *out_rights, uint32 *out_flags);
+
+#endif

--- a/kernel/proc/process.c
+++ b/kernel/proc/process.c
@@ -116,6 +116,7 @@ process_t *process_create(const char *name) {
     //initialize current working directory to root
     proc->cwd[0] = '/';
     proc->cwd[1] = '\0';
+    proc_context_init(&proc->context);
     
     proc->pagemap = NULL;
     proc->threads = NULL;
@@ -164,6 +165,7 @@ void process_destroy(process_t *proc) {
         }
     }
     kfree(proc->handles);
+    proc_context_destroy(&proc->context);
     
     //free user address space if present
     if (proc->pagemap) {

--- a/kernel/proc/process.h
+++ b/kernel/proc/process.h
@@ -4,6 +4,7 @@
 #include <arch/types.h>
 #include <obj/object.h>
 #include <obj/rights.h>
+#include <proc/context.h>
 #include <proc/wait.h>
 #include <lib/spinlock.h>
 
@@ -45,6 +46,7 @@ typedef struct process {
     char name[32];
     char cwd[256];  //current working directory
     uint32 state;
+    proc_context_t context; //typed inherited runtime context
     
     //kernel object wrapper (for capability-based access)
     object_t *obj;

--- a/kernel/syscall/context.c
+++ b/kernel/syscall/context.c
@@ -1,0 +1,187 @@
+#include <syscall/syscall.h>
+#include <proc/process.h>
+#include <proc/context.h>
+#include <mm/kheap.h>
+#include <lib/string.h>
+
+#define CONTEXT_MAX_STRING 4096
+
+static int copy_context_key(const char *user_key, char key[PROC_CONTEXT_KEY_MAX]) {
+    if (!user_key) return -1;
+    return copy_user_cstr(user_key, key, PROC_CONTEXT_KEY_MAX);
+}
+
+static int copy_context_flags(uint32 *user_flags, uint32 flags) {
+    if (!user_flags) return 0;
+    return copy_to_user_bytes(user_flags, &flags, sizeof(flags));
+}
+
+intptr sys_context_set(const char *key, uint32 type, const void *value_ptr, size value_len, uint32 flags) {
+    process_t *proc = process_current();
+    char k_key[PROC_CONTEXT_KEY_MAX];
+
+    if (!proc) return -1;
+    if (copy_context_key(key, k_key) != 0) return -1;
+
+    if (type == CONTEXT_VALUE_STRING) {
+        if (!value_ptr || value_len == 0 || value_len > CONTEXT_MAX_STRING) return -1;
+
+        char *tmp = kmalloc(value_len);
+        if (!tmp) return -1;
+
+        if (copy_user_bytes(value_ptr, tmp, value_len) != 0) {
+            kfree(tmp);
+            return -1;
+        }
+        if (tmp[value_len - 1] != '\0') {
+            kfree(tmp);
+            return -1;
+        }
+
+        int rc = proc_context_set_string(&proc->context, k_key, tmp, flags);
+        kfree(tmp);
+        return rc;
+    }
+
+    if (type == CONTEXT_VALUE_I64) {
+        int64 value;
+        if (!value_ptr || value_len != sizeof(value)) return -1;
+        if (copy_user_bytes(value_ptr, &value, sizeof(value)) != 0) return -1;
+        return proc_context_set_i64(&proc->context, k_key, value, flags);
+    }
+
+    if (type == CONTEXT_VALUE_U64) {
+        uint64 value;
+        if (!value_ptr || value_len != sizeof(value)) return -1;
+        if (copy_user_bytes(value_ptr, &value, sizeof(value)) != 0) return -1;
+        return proc_context_set_u64(&proc->context, k_key, value, flags);
+    }
+
+    if (type == CONTEXT_VALUE_BOOL) {
+        uint32 value;
+        if (!value_ptr || value_len != sizeof(value)) return -1;
+        if (copy_user_bytes(value_ptr, &value, sizeof(value)) != 0) return -1;
+        return proc_context_set_bool(&proc->context, k_key, value != 0, flags);
+    }
+
+    return -1;
+}
+
+intptr sys_context_get(const char *key, uint32 type, void *value_ptr, size value_len, uint32 *flags_out) {
+    process_t *proc = process_current();
+    char k_key[PROC_CONTEXT_KEY_MAX];
+    uint32 flags = 0;
+
+    if (!proc) return -1;
+    if (copy_context_key(key, k_key) != 0) return -1;
+
+    if (type == CONTEXT_VALUE_STRING) {
+        char *tmp = NULL;
+        size len = 0;
+
+        if (proc_context_get_string_dup(&proc->context, k_key, &tmp, &len, &flags) != 0) {
+            return -1;
+        }
+
+        if (!value_ptr || value_len < len) {
+            kfree(tmp);
+            return -1;
+        }
+
+        if (copy_to_user_bytes(value_ptr, tmp, len) != 0) {
+            kfree(tmp);
+            return -1;
+        }
+
+        kfree(tmp);
+        if (copy_context_flags(flags_out, flags) != 0) return -1;
+        return (intptr)len;
+    }
+
+    if (type == CONTEXT_VALUE_I64) {
+        int64 value;
+        if (!value_ptr || value_len < sizeof(value)) return -1;
+        if (proc_context_get_i64(&proc->context, k_key, &value, &flags) != 0) return -1;
+        if (copy_to_user_bytes(value_ptr, &value, sizeof(value)) != 0) return -1;
+        if (copy_context_flags(flags_out, flags) != 0) return -1;
+        return 0;
+    }
+
+    if (type == CONTEXT_VALUE_U64) {
+        uint64 value;
+        if (!value_ptr || value_len < sizeof(value)) return -1;
+        if (proc_context_get_u64(&proc->context, k_key, &value, &flags) != 0) return -1;
+        if (copy_to_user_bytes(value_ptr, &value, sizeof(value)) != 0) return -1;
+        if (copy_context_flags(flags_out, flags) != 0) return -1;
+        return 0;
+    }
+
+    if (type == CONTEXT_VALUE_BOOL) {
+        uint32 value = 0;
+        int boolean = 0;
+        if (!value_ptr || value_len < sizeof(value)) return -1;
+        if (proc_context_get_bool(&proc->context, k_key, &boolean, &flags) != 0) return -1;
+        value = boolean ? 1u : 0u;
+        if (copy_to_user_bytes(value_ptr, &value, sizeof(value)) != 0) return -1;
+        if (copy_context_flags(flags_out, flags) != 0) return -1;
+        return 0;
+    }
+
+    return -1;
+}
+
+intptr sys_context_set_handle(const char *key, handle_t h, uint32 flags) {
+    process_t *proc = process_current();
+    char k_key[PROC_CONTEXT_KEY_MAX];
+    proc_handle_t *entry;
+
+    if (!proc) return -1;
+    if (copy_context_key(key, k_key) != 0) return -1;
+
+    entry = process_get_handle_entry(proc, h);
+    if (!entry) return -1;
+
+    //the context stores the object plus its rights snapshot so inheritance
+    //keeps the same capability envelope without eagerly minting child handles
+    return proc_context_set_object(&proc->context, k_key, entry->obj, entry->rights, flags);
+}
+
+intptr sys_context_get_handle(const char *key, handle_t *out_h, uint32 *flags_out) {
+    process_t *proc = process_current();
+    char k_key[PROC_CONTEXT_KEY_MAX];
+    object_t *obj = NULL;
+    handle_rights_t rights = HANDLE_RIGHT_NONE;
+    uint32 flags = 0;
+    int new_handle;
+
+    if (!proc || !out_h) return -1;
+    if (copy_context_key(key, k_key) != 0) return -1;
+
+    if (proc_context_get_object_ref(&proc->context, k_key, &obj, &rights, &flags) != 0) {
+        return -1;
+    }
+
+    new_handle = process_grant_handle(proc, obj, rights);
+    object_deref(obj);
+    if (new_handle < 0) return -1;
+
+    if (copy_context_flags(flags_out, flags) != 0) {
+        process_close_handle(proc, new_handle);
+        return -1;
+    }
+    if (copy_to_user_bytes(out_h, &new_handle, sizeof(new_handle)) != 0) {
+        process_close_handle(proc, new_handle);
+        return -1;
+    }
+
+    return 0;
+}
+
+intptr sys_context_remove(const char *key) {
+    process_t *proc = process_current();
+    char k_key[PROC_CONTEXT_KEY_MAX];
+
+    if (!proc) return -1;
+    if (copy_context_key(key, k_key) != 0) return -1;
+    return proc_context_remove(&proc->context, k_key);
+}

--- a/kernel/syscall/fs.c
+++ b/kernel/syscall/fs.c
@@ -11,63 +11,7 @@
 #include <errno.h>
 #include <atomic.h>
 
-static __attribute__((noinline)) int write_user_byte(uint8 *ptr, uint8 value) {
-    percpu_t *cpu = percpu_get();
-    cpu->recovery_rip = (uintptr)&&fault;
-    atomic_signal_fence(memory_order_seq_cst);
-    *ptr = value;
-    atomic_signal_fence(memory_order_seq_cst);
-    cpu->recovery_rip = 0;
-    return 0;
-fault:
-    cpu->recovery_rip = 0;
-    return -EFAULT;
-}
-
 #define MAX_HANDLE_IO (1u << 20)
-
-static int copy_to_user_bytes(void *user_ptr, const void *kernel_buf, size len) {
-    if (len == 0) return 0;
-    if (!user_ptr || !kernel_buf) return -EFAULT;
-
-    uintptr dst_addr = (uintptr)user_ptr;
-    if (dst_addr < USER_SPACE_START || dst_addr >= USER_SPACE_END) return -EFAULT;
-    if (len > (size)(USER_SPACE_END - dst_addr)) return -EFAULT;
-
-    const uint8 *src = (const uint8 *)kernel_buf;
-    uint8 *dst = (uint8 *)user_ptr;
-    size i = 0;
-
-    while (i < len && ((uintptr)&dst[i] & (sizeof(uintptr) - 1))) {
-        if (write_user_byte(&dst[i], src[i]) != 0) return -EFAULT;
-        i++;
-    }
-
-    if (i + sizeof(uintptr) <= len) {
-        percpu_t *cpu = percpu_get();
-        cpu->recovery_rip = (uintptr)&&bulk_fault;
-
-        while (i + sizeof(uintptr) <= len) {
-            uintptr tmp = 0;
-            memcpy(&tmp, &src[i], sizeof(tmp));
-            *(uintptr *)&dst[i] = tmp;
-            i += sizeof(uintptr);
-        }
-
-        cpu->recovery_rip = 0;
-    }
-
-    while (i < len) {
-        if (write_user_byte(&dst[i], src[i]) != 0) return -EFAULT;
-        i++;
-    }
-
-    return 0;
-
-bulk_fault:
-    percpu_get()->recovery_rip = 0;
-    return -EFAULT;
-}
 
 intptr sys_handle_read(handle_t h, void *buf, size len) {
     if (!buf || len == 0) return -1;

--- a/kernel/syscall/misc.c
+++ b/kernel/syscall/misc.c
@@ -20,7 +20,7 @@ fault:
     return -EFAULT;
 }
 
-static int copy_to_user_bytes(void *user_ptr, const void *kernel_buf, size len) {
+int copy_to_user_bytes(void *user_ptr, const void *kernel_buf, size len) {
     if (len == 0) return 0;
     if (!user_ptr || !kernel_buf) return -EFAULT;
 

--- a/kernel/syscall/proc.c
+++ b/kernel/syscall/proc.c
@@ -9,81 +9,190 @@
 #include <lib/io.h>
 #include <obj/handle.h>
 
-intptr sys_exit(intptr status) {
-    process_current()->exit_code = status;
-    thread_exit();
-    return 0;
-}
+//strings are copied through this temporary kernel buffer limit before they are
+//duplicated again into the destination process cotext
+#define PROC_CONTEXT_MAX_STRING 4096
+#define PROC_CONTEXT_MAX_OVERRIDES 64
+#define MAX_EXEC_BUFFER (32 * 1024 * 1024)
 
-intptr sys_getpid(void) {
-    process_t *proc = process_current();
-    if (proc) {
-        return (intptr)proc->pid;
+//copy the parent baseline into the child before any one-shot spawn override is applied 
+static int process_inherit_runtime_state(process_t *child, process_t *parent) {
+    if (!child || !parent) return 0;
+
+    //keep process-local startup state together so spawn and manual process
+    //creation do not drift apart as ABI grows
+    strncpy(child->cwd, parent->cwd, sizeof(child->cwd) - 1);
+    child->cwd[sizeof(child->cwd) - 1] = '\0';
+
+    if (proc_context_clone_for_child(&child->context, &parent->context) != 0) {
+        return -1;
     }
+
     return 0;
 }
 
-intptr sys_yield(void) {
-    sched_yield();
+//apply one user-provided override entry onto a freshly created child process
+static int process_apply_context_override(process_t *target, process_t *source,
+                                          const context_spawn_entry_t *entry) {
+    char key[PROC_CONTEXT_KEY_MAX];
+
+    if (!target || !source || !entry) return -1;
+    if (copy_user_cstr(entry->key, key, sizeof(key)) != 0) return -1;
+
+    //spawn overrides are parent-authoritative, so they may replace inherited
+    //ead-only entries before the child is allowed to run
+    if (proc_context_remove_force(&target->context, key) != 0) {
+        proc_context_entry_t *existing = NULL;
+
+        spinlock_acquire(&target->context.lock);
+        for (size i = 0; i < target->context.count; i++) {
+            if (target->context.entries[i].key &&
+                strcmp(target->context.entries[i].key, key) == 0) {
+                existing = &target->context.entries[i];
+                break;
+            }
+        }
+        spinlock_release(&target->context.lock);
+
+        if (existing) return -1;
+    }
+
+    if (entry->type == CONTEXT_VALUE_STRING) {
+        char *tmp;
+
+        if (!entry->value.ptr || entry->value_len == 0 || entry->value_len > PROC_CONTEXT_MAX_STRING) {
+            return -1;
+        }
+
+        tmp = kmalloc(entry->value_len);
+        if (!tmp) return -1;
+        if (copy_user_bytes(entry->value.ptr, tmp, entry->value_len) != 0) {
+            kfree(tmp);
+            return -1;
+        }
+        if (tmp[entry->value_len - 1] != '\0') {
+            kfree(tmp);
+            return -1;
+        }
+
+        int rc = proc_context_set_string(&target->context, key, tmp, entry->flags);
+        kfree(tmp);
+        return rc;
+    }
+
+    if (entry->type == CONTEXT_VALUE_I64) {
+        return proc_context_set_i64(&target->context, key, entry->value.i64, entry->flags);
+    }
+
+    if (entry->type == CONTEXT_VALUE_U64) {
+        return proc_context_set_u64(&target->context, key, entry->value.u64, entry->flags);
+    }
+
+    if (entry->type == CONTEXT_VALUE_BOOL) {
+        return proc_context_set_bool(&target->context, key, entry->value.boolean != 0, entry->flags);
+    }
+
+    if (entry->type == CONTEXT_VALUE_OBJECT) {
+        proc_handle_t *handle_entry = process_get_handle_entry(source, entry->value.handle);
+        if (!handle_entry) return -1;
+
+        //capture the parent's current handle rights so the child receives the
+        //same capability envelope when it materializes the entry later
+        return proc_context_set_object(&target->context, key, handle_entry->obj,
+                                       handle_entry->rights, entry->flags);
+    }
+
+    return -1;
+}
+
+//copy the override array out of userspace one entry at a time and apply it
+static int process_apply_context_overrides(process_t *target, process_t *source,
+                                           const context_spawn_entry_t *entries, size entry_count) {
+    if (!entries || entry_count == 0) return 0;
+    if (entry_count > PROC_CONTEXT_MAX_OVERRIDES) return -1;
+
+    for (size i = 0; i < entry_count; i++) {
+        context_spawn_entry_t entry;
+
+        if (copy_user_bytes(&entries[i], &entry, sizeof(entry)) != 0) {
+            return -1;
+        }
+
+        //overrides are applied after inheritance so the parent can replace a
+        //single child launch without mutating its own process context
+        if (process_apply_context_override(target, source, &entry) != 0) {
+            return -1;
+        }
+    }
+
     return 0;
 }
 
-intptr sys_spawn(const char *path, int argc, char **argv) {
+//shared implementation fospawn() and spawn_ctx()
+static intptr sys_spawn_impl(const char *path, int argc, char **argv,
+                             const context_spawn_entry_t *entries, size entry_count) {
+    if (entry_count > 0 && !entries) return -1;
+
     //open path
     handle_t h = handle_open(path, HANDLE_RIGHT_READ);
     if (h == INVALID_HANDLE) {
         return -1;
     }
-    
+
     //get file size
     stat_t st;
     if (handle_stat(path, &st) != 0) {
         handle_close(h);
         return -1;
     }
-    
+
     //allocate buffer for exec binary
     size buf_size = st.size;
-    #define MAX_EXEC_BUFFER (32 * 1024 * 1024) //32MB limit
     if (buf_size == 0 || buf_size > MAX_EXEC_BUFFER) {
         handle_close(h);
         return -1;
     }
-    
+
     char *buf = kmalloc(buf_size);
     if (!buf) {
         handle_close(h);
         return -1;
     }
-    
+
     ssize len = handle_read(h, buf, buf_size);
     handle_close(h);
-    
+
     if (len <= 0) {
         kfree(buf);
         return -1;
     }
-    
+
     //validate ELF
     if (!elf_validate(buf, len)) {
         kfree(buf);
         return -1;
     }
-    
+
     //create suspended user process (capability-based model)
     process_t *proc = process_create_user_suspended(path);
     if (!proc) {
         kfree(buf);
         return -1;
     }
-    
-    //inherit CWD from current process
+
+    //inherit baseline runtime state before any one-off child override lands
     process_t *current = process_current();
-    if (current) {
-        strncpy(proc->cwd, current->cwd, sizeof(proc->cwd) - 1);
-        proc->cwd[sizeof(proc->cwd) - 1] = '\0';
+    if (current && process_inherit_runtime_state(proc, current) != 0) {
+        process_destroy(proc);
+        kfree(buf);
+        return -1;
     }
-    
+    if (current && process_apply_context_overrides(proc, current, entries, entry_count) != 0) {
+        process_destroy(proc);
+        kfree(buf);
+        return -1;
+    }
+
     //load ELF into user address space
     elf_load_info_t info;
     int err = elf_load_user(buf, len, proc, &info);
@@ -92,11 +201,11 @@ intptr sys_spawn(const char *path, int argc, char **argv) {
         kfree(buf);
         return -1;
     }
-    
+
     //check for dynamic executable (has interpreter)
     uint64 interp_base = 0;
     uint64 real_entry = info.entry;
-    
+
     if (info.interp_path[0]) {
         char interp_fullpath[256];
         if (info.interp_path[0] == '/') {
@@ -104,14 +213,14 @@ intptr sys_spawn(const char *path, int argc, char **argv) {
         } else {
             snprintf(interp_fullpath, sizeof(interp_fullpath), "$files/%s", info.interp_path);
         }
-        
+
         handle_t ih = handle_open(interp_fullpath, HANDLE_RIGHT_READ);
         if (ih == INVALID_HANDLE) {
             process_destroy(proc);
             kfree(buf);
             return -1;
         }
-        
+
         stat_t ist;
         if (handle_stat(interp_fullpath, &ist) != 0) {
             handle_close(ih);
@@ -138,14 +247,14 @@ intptr sys_spawn(const char *path, int argc, char **argv) {
 
         ssize interp_len = handle_read(ih, interp_buf, interp_buf_size);
         handle_close(ih);
-        
+
         if (interp_len <= 0 || !elf_validate(interp_buf, interp_len)) {
             process_destroy(proc);
             kfree(interp_buf);
             kfree(buf);
             return -1;
         }
-        
+
         elf_load_info_t interp_info;
         err = elf_load_user(interp_buf, interp_len, proc, &interp_info);
         if (err != ELF_OK) {
@@ -154,26 +263,26 @@ intptr sys_spawn(const char *path, int argc, char **argv) {
             kfree(buf);
             return -1;
         }
-        
+
         interp_base = interp_info.virt_base;
         real_entry = interp_info.entry;
         kfree(interp_buf);
     }
-    
+
     uintptr user_stack_base = 0x7FFFFFFFE000ULL;
     size stack_size = 0x2000;
-    
+
     uintptr stack_phys = (uintptr)pmm_alloc(stack_size / 4096);
     if (!stack_phys) {
         return -1;
     }
-    
-    mmu_map_range(proc->pagemap, user_stack_base - stack_size, stack_phys, 
+
+    mmu_map_range(proc->pagemap, user_stack_base - stack_size, stack_phys,
                   stack_size / 4096, MMU_FLAG_WRITE | MMU_FLAG_USER);
-    
-    process_vma_add(proc, user_stack_base - stack_size, stack_size, 
+
+    process_vma_add(proc, user_stack_base - stack_size, stack_size,
                     MMU_FLAG_WRITE | MMU_FLAG_USER, NULL, 0);
-    
+
     uintptr user_stack_top;
     if (info.interp_path[0]) {
         user_stack_top = process_setup_user_stack_dynamic(
@@ -182,19 +291,47 @@ intptr sys_spawn(const char *path, int argc, char **argv) {
             info.entry, interp_base
         );
     } else {
-        user_stack_top = process_setup_user_stack(stack_phys, user_stack_base, 
-                                                   stack_size, argc, argv);
+        user_stack_top = process_setup_user_stack(stack_phys, user_stack_base,
+                                                  stack_size, argc, argv);
     }
-    
+
     thread_t *thread = thread_create_user(proc, (void*)real_entry, (void*)user_stack_top);
     if (!thread) {
         kfree(buf);
         return -1;
     }
-    
+
     sched_add(thread);
     kfree(buf);
     return (intptr)proc->pid;
+}
+
+intptr sys_exit(intptr status) {
+    process_current()->exit_code = status;
+    thread_exit();
+    return 0;
+}
+
+intptr sys_getpid(void) {
+    process_t *proc = process_current();
+    if (proc) {
+        return (intptr)proc->pid;
+    }
+    return 0;
+}
+
+intptr sys_yield(void) {
+    sched_yield();
+    return 0;
+}
+
+intptr sys_spawn(const char *path, int argc, char **argv) {
+    return sys_spawn_impl(path, argc, argv, NULL, 0);
+}
+
+intptr sys_spawn_ctx(const char *path, int argc, char **argv,
+                     const context_spawn_entry_t *entries, size entry_count) {
+    return sys_spawn_impl(path, argc, argv, entries, entry_count);
 }
 
 intptr sys_wait(uintptr pid) {
@@ -215,37 +352,42 @@ intptr sys_wait(uintptr pid) {
 
 intptr sys_process_create(const char *name) {
     if (!name) return -1;
-    
+
     process_t *current = process_current();
     if (!current) return -1;
-    
+
     process_t *child = process_create_user_suspended(name);
     if (!child) return -1;
-    
+
+    if (process_inherit_runtime_state(child, current) != 0) {
+        process_destroy(child);
+        return -1;
+    }
+
     int h = process_grant_handle(current, child->obj, HANDLE_RIGHTS_ALL);
     if (h < 0) {
         process_destroy(child);
         return -1;
     }
-    
+
     return h;
 }
 
 intptr sys_handle_grant(handle_t proc_h, handle_t local_h, handle_rights_t rights) {
     process_t *current = process_current();
     if (!current) return -1;
-    
+
     object_t *proc_obj = process_get_handle(current, proc_h);
     if (!proc_obj || proc_obj->type != OBJECT_PROCESS) return -2;
-    
+
     process_t *target = (process_t *)proc_obj->data;
     if (!target) return -3;
-    
+
     proc_handle_t *entry = process_get_handle_entry(current, local_h);
     if (!entry) return -4;
-    
+
     handle_rights_t actual_rights = rights_reduce(entry->rights, rights);
-    
+
     int new_h = process_inject_handle(target, entry->obj, actual_rights);
     return new_h;
 }
@@ -253,16 +395,16 @@ intptr sys_handle_grant(handle_t proc_h, handle_t local_h, handle_rights_t right
 intptr sys_process_start(handle_t proc_h, uintptr entry, uintptr stack) {
     process_t *current = process_current();
     if (!current) return -1;
-    
+
     object_t *proc_obj = process_get_handle(current, proc_h);
     if (!proc_obj || proc_obj->type != OBJECT_PROCESS) return -2;
-    
+
     process_t *target = (process_t *)proc_obj->data;
     if (!target) return -3;
-    
+
     thread_t *thread = thread_create_user(target, (void *)entry, (void *)stack);
     if (!thread) return -4;
-    
+
     sched_add(thread);
     return (intptr)target->pid;
 }

--- a/kernel/syscall/syscall.c
+++ b/kernel/syscall/syscall.c
@@ -10,6 +10,8 @@ intptr syscall_dispatch(uintptr num, uintptr arg1, uintptr arg2, uintptr arg3,
         case SYS_YIELD: return sys_yield();
         case SYS_DEBUG_WRITE: return sys_debug_write((const char *)arg1, (size)arg2);
         case SYS_SPAWN: return sys_spawn((const char *)arg1, (int)arg2, (char **)arg3);
+        case SYS_SPAWN_CTX: return sys_spawn_ctx((const char *)arg1, (int)arg2, (char **)arg3,
+                                                 (const context_spawn_entry_t *)arg4, (size)arg5);
         case SYS_GET_OBJ: return sys_get_obj((handle_t)arg1, (const char *)arg2, (handle_rights_t)arg3);
         case SYS_HANDLE_READ: return sys_handle_read((handle_t)arg1, (void *)arg2, (size)arg3);
         case SYS_HANDLE_WRITE: return sys_handle_write((handle_t)arg1, (const void *)arg2, (size)arg3);
@@ -57,6 +59,13 @@ intptr syscall_dispatch(uintptr num, uintptr arg1, uintptr arg2, uintptr arg3,
         case SYS_TCP_CONNECT: return sys_tcp_connect((uint32)arg1, (const void *)arg2, (uint32)arg3, (uint16)arg4);
         case SYS_TCP_LISTEN: return sys_tcp_listen((uint32)arg1, (const void *)arg2, (uint32)arg3, (uint16)arg4);
         case SYS_TCP_ACCEPT: return sys_tcp_accept((handle_t)arg1);
+        case SYS_CONTEXT_SET: return sys_context_set((const char *)arg1, (uint32)arg2,
+                                                     (const void *)arg3, (size)arg4, (uint32)arg5);
+        case SYS_CONTEXT_GET: return sys_context_get((const char *)arg1, (uint32)arg2,
+                                                     (void *)arg3, (size)arg4, (uint32 *)arg5);
+        case SYS_CONTEXT_SET_HANDLE: return sys_context_set_handle((const char *)arg1, (handle_t)arg2, (uint32)arg3);
+        case SYS_CONTEXT_GET_HANDLE: return sys_context_get_handle((const char *)arg1, (handle_t *)arg2, (uint32 *)arg3);
+        case SYS_CONTEXT_REMOVE: return sys_context_remove((const char *)arg1);
         
         default: return -1;
     }

--- a/kernel/syscall/syscall.h
+++ b/kernel/syscall/syscall.h
@@ -10,6 +10,7 @@
 #define SYS_GETPID          1
 #define SYS_YIELD           2
 #define SYS_SPAWN           4   //spawns a new process
+#define SYS_SPAWN_CTX       77  //spawn with per-child context overrides
 #define SYS_WAIT            47  //wait for process to exit
 #define SYS_PROCESS_CREATE  50  //create suspended process, returns handle
 #define SYS_HANDLE_GRANT    51  //inject handle into child process
@@ -44,6 +45,11 @@
 #define SYS_CHDIR           55  //change current working directory
 #define SYS_GETCWD          56  //get current working directory
 #define SYS_MOUNT           69  //mount a filesystem
+#define SYS_CONTEXT_SET     72  //set a typed process context entry
+#define SYS_CONTEXT_GET     73  //get a typed process context entry
+#define SYS_CONTEXT_SET_HANDLE 74 //capture a handle-backed process context entry
+#define SYS_CONTEXT_GET_HANDLE 75 //materialize a handle from a context entry
+#define SYS_CONTEXT_REMOVE  76  //remove a process context entry
 #define SYS_MKNODE          58  //create fs node
 #define SYS_REMOVE          59  //remove file or directory
 #define SYS_HANDLE_READ     6   //read from handle
@@ -141,6 +147,31 @@ typedef struct {
     uint32 sender_pid;   //PID of the process that sent this message (0 if kernel)
 } channel_recv_result_t;
 
+typedef enum {
+    CONTEXT_VALUE_STRING = 1,
+    CONTEXT_VALUE_I64 = 2,
+    CONTEXT_VALUE_U64 = 3,
+    CONTEXT_VALUE_BOOL = 4,
+    CONTEXT_VALUE_OBJECT = 5
+} context_value_type_t;
+
+#define CONTEXT_FLAG_INHERIT   (1u << 0)
+#define CONTEXT_FLAG_READONLY  (1u << 1)
+
+typedef struct {
+    const char *key;
+    uint32 type;
+    uint32 flags;
+    size value_len;
+    union {
+        const void *ptr;
+        int64 i64;
+        uint64 u64;
+        uint32 boolean;
+        handle_t handle;
+    } value;
+} context_spawn_entry_t;
+
 intptr syscall_dispatch(uintptr num, uintptr arg1, uintptr arg2, uintptr arg3,
                        uintptr arg4, uintptr arg5, uintptr arg6);
 
@@ -151,6 +182,8 @@ intptr sys_exit(intptr status);
 intptr sys_getpid(void);
 intptr sys_yield(void);
 intptr sys_spawn(const char *path, int argc, char **argv);
+intptr sys_spawn_ctx(const char *path, int argc, char **argv,
+                     const context_spawn_entry_t *entries, size entry_count);
 intptr sys_wait(uintptr pid);
 intptr sys_process_create(const char *name);
 intptr sys_handle_grant(handle_t proc_h, handle_t local_h, handle_rights_t rights);
@@ -197,9 +230,15 @@ intptr sys_dns_resolve_aaaa(const char *hostname, uint8 *ipv6_out);
 intptr sys_tcp_connect(uint32 family, const void *dst_addr, uint32 addr_len, uint16 port);
 intptr sys_tcp_listen(uint32 family, const void *local_addr, uint32 addr_len, uint16 port);
 intptr sys_tcp_accept(handle_t listen_h);
+intptr sys_context_set(const char *key, uint32 type, const void *value_ptr, size value_len, uint32 flags);
+intptr sys_context_get(const char *key, uint32 type, void *value_ptr, size value_len, uint32 *flags_out);
+intptr sys_context_set_handle(const char *key, handle_t h, uint32 flags);
+intptr sys_context_get_handle(const char *key, handle_t *out_h, uint32 *flags_out);
+intptr sys_context_remove(const char *key);
 
 //helper for safe user-space copies
 int copy_user_bytes(const void *user_ptr, void *kernel_buf, size len);
 int copy_user_cstr(const char *user_str, char *kernel_buf, size kernel_len);
+int copy_to_user_bytes(void *user_ptr, const void *kernel_buf, size len);
 
 #endif

--- a/user/libc/include/sys/syscall.h
+++ b/user/libc/include/sys/syscall.h
@@ -6,6 +6,7 @@
 #define SYS_YIELD           2
 #define SYS_DEBUG_WRITE     3
 #define SYS_SPAWN           4
+#define SYS_SPAWN_CTX       77
 #define SYS_GET_OBJ         5
 #define SYS_HANDLE_READ     6
 #define SYS_HANDLE_WRITE    7
@@ -50,6 +51,11 @@
 #define SYS_TCP_ACCEPT      68
 #define SYS_MOUNT           69
 #define SYS_DNS_RESOLVE_AAAA 71 //resolve hostname to IPv6 address (AAAA)
+#define SYS_CONTEXT_SET     72
+#define SYS_CONTEXT_GET     73
+#define SYS_CONTEXT_SET_HANDLE 74
+#define SYS_CONTEXT_GET_HANDLE 75
+#define SYS_CONTEXT_REMOVE  76
 
 #define SYS_MAX             256
 

--- a/user/libc/include/system.h
+++ b/user/libc/include/system.h
@@ -23,11 +23,37 @@ typedef int32 handle_t;
 //invalid handle sentinel
 #define INVALID_HANDLE      (-1)
 
+typedef enum {
+    CONTEXT_VALUE_STRING = 1,
+    CONTEXT_VALUE_I64 = 2,
+    CONTEXT_VALUE_U64 = 3,
+    CONTEXT_VALUE_BOOL = 4,
+    CONTEXT_VALUE_OBJECT = 5
+} context_value_type_t;
+
+#define CONTEXT_FLAG_INHERIT   (1u << 0)
+#define CONTEXT_FLAG_READONLY  (1u << 1)
+
+typedef struct {
+    const char *key;
+    uint32 type;
+    uint32 flags;
+    size value_len;
+    union {
+        const void *ptr;
+        int64 i64;
+        uint64 u64;
+        uint32 boolean;
+        handle_t handle;
+    } value;
+} context_spawn_entry_t;
+
 //process control
 void exit(int code);
 int64 getpid(void);
 void yield(void);
 int spawn(char *path, int argc, char **argv);
+int spawn_ctx(char *path, int argc, char **argv, const context_spawn_entry_t *entries, size entry_count);
 int wait(int pid);
 uint64 get_ticks(void);
 
@@ -174,6 +200,19 @@ typedef struct {
 } system_stats_t;
 
 int object_get_info(handle_t h, uint32 topic, void *ptr, uint64 len);
+
+//typed process context
+int context_set_string(const char *key, const char *value, uint32 flags);
+int context_set_i64(const char *key, int64 value, uint32 flags);
+int context_set_u64(const char *key, uint64 value, uint32 flags);
+int context_set_bool(const char *key, int value, uint32 flags);
+int context_set_handle(const char *key, handle_t h, uint32 flags);
+int context_get_string(const char *key, char *buf, size bufsize, uint32 *flags_out);
+int context_get_i64(const char *key, int64 *out_value, uint32 *flags_out);
+int context_get_u64(const char *key, uint64 *out_value, uint32 *flags_out);
+int context_get_bool(const char *key, int *out_value, uint32 *flags_out);
+int context_get_handle(const char *key, handle_t *out_h, uint32 *flags_out);
+int context_remove(const char *key);
 
 //networking
 #define IPV6_ADDR_LEN 16

--- a/user/libc/src/system/context.c
+++ b/user/libc/src/system/context.c
@@ -1,0 +1,61 @@
+#include <system.h>
+#include <sys/syscall.h>
+#include <string.h>
+
+int context_set_string(const char *key, const char *value, uint32 flags) {
+    if (!value) return -1;
+    return (int)__syscall5(SYS_CONTEXT_SET, (long)key, CONTEXT_VALUE_STRING,
+                           (long)value, (long)(strlen(value) + 1), (long)flags);
+}
+
+int context_set_i64(const char *key, int64 value, uint32 flags) {
+    return (int)__syscall5(SYS_CONTEXT_SET, (long)key, CONTEXT_VALUE_I64,
+                           (long)&value, sizeof(value), (long)flags);
+}
+
+int context_set_u64(const char *key, uint64 value, uint32 flags) {
+    return (int)__syscall5(SYS_CONTEXT_SET, (long)key, CONTEXT_VALUE_U64,
+                           (long)&value, sizeof(value), (long)flags);
+}
+
+int context_set_bool(const char *key, int value, uint32 flags) {
+    uint32 boolean = value ? 1u : 0u;
+    return (int)__syscall5(SYS_CONTEXT_SET, (long)key, CONTEXT_VALUE_BOOL,
+                           (long)&boolean, sizeof(boolean), (long)flags);
+}
+
+int context_set_handle(const char *key, handle_t h, uint32 flags) {
+    return (int)__syscall3(SYS_CONTEXT_SET_HANDLE, (long)key, (long)h, (long)flags);
+}
+
+int context_get_string(const char *key, char *buf, size bufsize, uint32 *flags_out) {
+    return (int)__syscall5(SYS_CONTEXT_GET, (long)key, CONTEXT_VALUE_STRING,
+                           (long)buf, (long)bufsize, (long)flags_out);
+}
+
+int context_get_i64(const char *key, int64 *out_value, uint32 *flags_out) {
+    return (int)__syscall5(SYS_CONTEXT_GET, (long)key, CONTEXT_VALUE_I64,
+                           (long)out_value, sizeof(*out_value), (long)flags_out);
+}
+
+int context_get_u64(const char *key, uint64 *out_value, uint32 *flags_out) {
+    return (int)__syscall5(SYS_CONTEXT_GET, (long)key, CONTEXT_VALUE_U64,
+                           (long)out_value, sizeof(*out_value), (long)flags_out);
+}
+
+int context_get_bool(const char *key, int *out_value, uint32 *flags_out) {
+    uint32 boolean = 0;
+    int rc = (int)__syscall5(SYS_CONTEXT_GET, (long)key, CONTEXT_VALUE_BOOL,
+                             (long)&boolean, sizeof(boolean), (long)flags_out);
+    if (rc < 0) return rc;
+    if (out_value) *out_value = boolean ? 1 : 0;
+    return 0;
+}
+
+int context_get_handle(const char *key, handle_t *out_h, uint32 *flags_out) {
+    return (int)__syscall3(SYS_CONTEXT_GET_HANDLE, (long)key, (long)out_h, (long)flags_out);
+}
+
+int context_remove(const char *key) {
+    return (int)__syscall1(SYS_CONTEXT_REMOVE, (long)key);
+}

--- a/user/libc/src/system/spawn.c
+++ b/user/libc/src/system/spawn.c
@@ -1,7 +1,10 @@
+#include <system.h>
 #include <sys/syscall.h>
 
-// __syscall3(SYS_SPAWN, (long)"/initrd/init", 1, (long)(char*[]){"/initrd/init", NULL});
-
 int spawn(char *path, int argc, char **argv) {
-    return __syscall3(SYS_SPAWN, (long)path, argc, (long)argv);
+    return spawn_ctx(path, argc, argv, NULL, 0);
+}
+
+int spawn_ctx(char *path, int argc, char **argv, const context_spawn_entry_t *entries, size entry_count) {
+    return __syscall5(SYS_SPAWN_CTX, (long)path, argc, (long)argv, (long)entries, (long)entry_count);
 }

--- a/user/libc/src/system/stdlib.c
+++ b/user/libc/src/system/stdlib.c
@@ -38,7 +38,15 @@ double atof(const char *s) {
 }
 
 char *getenv(const char *name) {
-    return NULL;
+    static char value[256];
+
+    //getenv is kept as acompatibility shim over the typed process context
+    if (!name) return NULL;
+    if (context_get_string(name, value, sizeof(value), NULL) < 0) {
+        return NULL;
+    }
+
+    return value;
 }
 
 int atexit(void (*function)(void)) {

--- a/user/src/test/.config
+++ b/user/src/test/.config
@@ -1,1 +1,0 @@
-LDLIBS_test = -lkeyboard

--- a/user/src/test/main.c
+++ b/user/src/test/main.c
@@ -1,9 +1,0 @@
-#include <io.h>
-
-int main() {
-
-    puts("Testing...\n"
-        "\ebFFFFFF"
-        "You can't see me!!\n"
-        "\eb000000\n");
-}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Process context storage: Store and retrieve typed key/value data (strings, 64-bit integers, booleans, object handles) within a process
  * Context inheritance: Child processes automatically inherit parent context entries marked as inheritable
  * Context-aware process spawning: Create child processes with predefined context entries
  * Environment variable integration: getenv() now accesses process context instead of system environment

<!-- end of auto-generated comment: release notes by coderabbit.ai -->